### PR TITLE
[FIX] product_variant_configurator: When creating a sale order line, name  field need to be recomputed

### DIFF
--- a/product_variant_configurator/models/product_product.py
+++ b/product_variant_configurator/models/product_product.py
@@ -12,7 +12,8 @@ class ProductProduct(models.Model):
     _name = "product.product"
 
     # This is needed as the AbstractModel removes the delegated related field
-    name = fields.Char(related="product_tmpl_id.name")
+    name = fields.Char(related="product_tmpl_id.name", related_sudo=True,
+                       compute_sudo=True, store=True)
 
     @api.multi
     def _get_product_attributes_values_dict(self):


### PR DESCRIPTION
When creating a sale order line and the product has activated the warning
of sale, name of the product with sudo fails to search for it.
Only work with admin user

fix #153